### PR TITLE
added names to users

### DIFF
--- a/db/migrate/20210302111720_add_names_to_brokers.rb
+++ b/db/migrate/20210302111720_add_names_to_brokers.rb
@@ -1,0 +1,6 @@
+class AddNamesToBrokers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :brokers, :first_name, :string
+    add_column :brokers, :last_name, :string
+  end
+end

--- a/db/migrate/20210302111730_add_names_to_buyers.rb
+++ b/db/migrate/20210302111730_add_names_to_buyers.rb
@@ -1,0 +1,6 @@
+class AddNamesToBuyers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :buyers, :first_name, :string
+    add_column :buyers, :last_name, :string
+  end
+end

--- a/db/migrate/20210302111741_add_namesto_admins.rb
+++ b/db/migrate/20210302111741_add_namesto_admins.rb
@@ -1,0 +1,6 @@
+class AddNamestoAdmins < ActiveRecord::Migration[6.0]
+  def change
+    add_column :admins, :first_name, :string
+    add_column :admins, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_02_095615) do
+ActiveRecord::Schema.define(version: 2021_03_02_111741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2021_03_02_095615) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
@@ -35,6 +37,8 @@ ActiveRecord::Schema.define(version: 2021_03_02_095615) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_brokers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_brokers_on_reset_password_token", unique: true
   end
@@ -47,6 +51,8 @@ ActiveRecord::Schema.define(version: 2021_03_02_095615) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_buyers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_buyers_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## The Story
Since I was making the devise models for the different user types, it seems a good idea to add the following attributes on top of the default ones. Here's what's inside this PR:
- Adds 'first_name' attribute to the Broker, Buyer, and Admin models
- Adds 'last_name' attribute to the Broker, Buyer, and Admin models

## Screenshots
![Screen Shot 2021-03-02 at 7 33 10 PM](https://user-images.githubusercontent.com/15170570/109642622-2d44fb00-7b8e-11eb-9a6f-59822f9f54cc.png)
